### PR TITLE
ENH: Add support for BigIntegerField

### DIFF
--- a/etl_sync/generators.py
+++ b/etl_sync/generators.py
@@ -317,6 +317,7 @@ class InstanceGenerator(BaseInstanceGenerator):
         'TextField': _prepare_text,
         'BooleanField': _prepare_boolean,
         'IntegerField': _prepare_integer,
+        'BigIntegerField': _prepare_integer,
         'FloatField': _prepare_float
     }
 


### PR DESCRIPTION
Not sure if there is anything I can test on this.  It seems that the only thing that is tested for for integer is that the prepare works, which would also cover big integer.  This works in my application (after spending an hour of debugging!).   

Maybe its worth a warning in the prepare function if there is no preparation available for a specific field type? (right now it silently passes though with no preparation).